### PR TITLE
表記ルールチェック　「適切」が正しくつかわれているチェックの重複解消

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,12 +105,6 @@ def analyze_problem_doc(problem_doc, temp_problem_file_path):
                 result_check_font_of_unfit_item.section_number = section.section_number
                 result_check_font_of_unfit_item.question_number = q_idx + 1
                 problem_invalid_list.append(result_check_font_of_unfit_item)
-
-        # 選択肢設問の設問文で、「適切」ではなく「適当」となっているかチェックし、適切ならエラーを返す
-        check_keyword_exact_match_in_question_statement = ck.check_keyword_exact_match_in_question(question_texts)
-        if isinstance(check_keyword_exact_match_in_question_statement, InvalidItem):
-            check_keyword_exact_match_in_question_statement.section_number = section.section_number
-            problem_invalid_list.append(check_keyword_exact_match_in_question_statement)
     
         # 文書から「問」で始まるパラグラフを抽出する(各問の書き出しを取得する)
         extract_paragraphs = doc_util.extract_question_paragraphs(problem_doc, start=section.star_paragraph_index, end=section.end_paragraph_index)


### PR DESCRIPTION
## 目的・背景
重複チェックしてしまっていたため。

## 変更点
- 「適当」が設問文に正しく文中で使用されているかチェックする。正しく利用されていないものはリストアップしてエラーとして返すチェック処理が重複してしまっていたため、main.pyの60行目付近のチェックに集約する。

## 申し送り事項
- 無し

## 関連Issue

